### PR TITLE
Implement std::error::Error for EmlError

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+use std::error;
+use std::fmt;
 use std::io;
 
 #[derive(Debug)]
@@ -12,3 +14,15 @@ impl From<io::Error> for EmlError {
         EmlError::IoError
     }
 }
+
+impl fmt::Display for EmlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EmlError::UnexpectedEndOfStream(s) => write!(f, "Unexpected end of stream: {}", s),
+            EmlError::UnexpectedContent(s) => write!(f, "Unexpected content: {}", s),
+            EmlError::IoError => write!(f, "IO error"),
+        }
+    }
+}
+
+impl error::Error for EmlError {}


### PR DESCRIPTION
This patch implements `std::error::Error` and `std::fmt::Display` (as required by `Error`) for the `EmlError` enum.  This makes it possible to use `EmlError` with error handling crates like [anyhow](https://lib.rs/anyhow).