### PR TITLE
Improve errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,12 +6,12 @@ use std::io;
 pub enum EmlError {
     UnexpectedEndOfStream(String),
     UnexpectedContent(String),
-    IoError,
+    IoError(std::io::Error),
 }
 
 impl From<io::Error> for EmlError {
-    fn from(_: io::Error) -> Self {
-        EmlError::IoError
+    fn from(inner: io::Error) -> Self {
+        EmlError::IoError(inner)
     }
 }
 
@@ -20,7 +20,7 @@ impl fmt::Display for EmlError {
         match self {
             EmlError::UnexpectedEndOfStream(s) => write!(f, "Unexpected end of stream: {}", s),
             EmlError::UnexpectedContent(s) => write!(f, "Unexpected content: {}", s),
-            EmlError::IoError => write!(f, "IO error"),
+            EmlError::IoError(inner) => write!(f, "IO error: {}", inner),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 mod eml;
 mod errors;
 mod parser;
+use crate::errors::EmlError;
 use crate::parser::EmlParser;
 
-fn main() -> Result<(), std::io::Error> {
-    /*
+fn main() -> Result<(), EmlError> {
     let mut eml = EmlParser::from_file("test_emails/0.eml")?;
     if let Ok(parsed) = eml.parse() {
         println!("{:?}", parsed.to);
@@ -12,7 +12,6 @@ fn main() -> Result<(), std::io::Error> {
         println!("Failed to parse");
     }
     println!();
-    */
 
     let mut eml = EmlParser::from_file("test_emails/1.eml")?;
     if let Ok(parsed) = eml.parse() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@ use crate::eml::*;
 use crate::errors::EmlError;
 use regex::Regex;
 use std::fs;
-use std::io;
+//use std::io;
 use std::iter::Peekable;
 use std::path::Path;
 
@@ -44,8 +44,7 @@ impl EmlParser {
     /// doesn't provide an iterator over `char` that could give a `Peekable`.
     // One possible TODO is rolling something like https://github.com/C4K3/peekable-reader-rs into
     // this project.
-    //pub fn from_file(filename: &str) -> Result<Self, io::Error> {
-    pub fn from_file(filename: impl AsRef<Path>) -> Result<Self, io::Error> {
+    pub fn from_file(filename: impl AsRef<Path>) -> Result<Self, EmlError> {
         let content = fs::read_to_string(filename)?;
 
         Ok(EmlParser {
@@ -568,5 +567,15 @@ This is the start of the body
         };
 
         assert_eq!(parsed.to_string(), r#""John Q. Public" <john@example.com>"#);
+    }
+
+    #[test]
+    fn test_errors() {
+        let filename = "nonexistent.eml";
+        let parsed = EmlParser::from_file(filename);
+        assert!(parsed.is_err());
+
+        let errval = parsed.unwrap_err();
+        assert!(matches!(errval, EmlError::IoError(_inner)));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,6 @@ use crate::eml::*;
 use crate::errors::EmlError;
 use regex::Regex;
 use std::fs;
-//use std::io;
 use std::iter::Peekable;
 use std::path::Path;
 


### PR DESCRIPTION
Now using `EmlError` in the `parse` function. The `EmlError::IoError` variant now stores the inner `std::io::Error` and reports it. Also added test to cover file not found; would be good to add other tests as well.

#6 