### PR TITLE
Implement source for EmlError

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,4 +25,11 @@ impl fmt::Display for EmlError {
     }
 }
 
-impl error::Error for EmlError {}
+impl error::Error for EmlError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            EmlError::IoError(inner) => Some(inner),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
Since the `IoError` variant now stores the source error, we can implement the `source` method of the `std::error::Error` trait for the `EmlError` type. (The default implementation just returned `None`.)

This is a follow-up to #5 and #8.