### PR TITLE
Transform main.rs into example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ license-file = "LICENSE"
 keywords = ["eml", "parse", "email-parsing", "email"]
 exclude = [
 	"test_emails/*",
-	"src/main.rs",
 	"dfa_definition.txt",
 	"transition_graph.png",
 ]

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -1,8 +1,5 @@
-mod eml;
-mod errors;
-mod parser;
-use crate::errors::EmlError;
-use crate::parser::EmlParser;
+use eml_parser::errors::EmlError;
+use eml_parser::parser::EmlParser;
 
 fn main() -> Result<(), EmlError> {
     let mut eml = EmlParser::from_file("test_emails/0.eml")?;


### PR DESCRIPTION
The `main.rs` binary is just a demonstration on how to use the library, not a standalone tool.  This PR transforms it into the example `examples/parse.rs`.  This also fixes some compiler warnings about unused methods.