### PR TITLE
Issue 11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eml-parser"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Adam Shirey <adam@shirey.ch>"]
 edition = "2018"
 description = "A library for parsing .eml files."

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -100,8 +100,6 @@ impl EmlParser {
     ) -> Result<Eml, EmlError> {
         let headers = self.parse_header_fields(&mut char_input)?;
 
-        //self.remove_header_body_separator(&mut char_input)?;
-
         let mut result = Eml::default();
         result.body = self.parse_body();
 


### PR DESCRIPTION
Changing how header values are parsed for #11 .

Adding in the `EndOfHeader_*` enum variants lets us track when we've hit the end of the entire header versus just the end of one header value. Reading a header value will also consume the delimiters (CR, LF, CRLF for a single header value; CRCR, LFLF, CRLFCLRF for the last one before the body). Doing this, we no longer need `remove_header_body_separator` since it's handled by `read_field_body`.